### PR TITLE
Specify /bin/bash as the primary shell for Makefile. This fixes array…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 .PHONY: all
 all: build
 
+SHELL :=/bin/bash
+
 GOFMT :=gofmt -s
 GOIMPORTS :=goimports -e
 


### PR DESCRIPTION
… indexing issue in /bin/sh for Ubuntu precise.