### PR TITLE
Two spaces not tabs for help examples

### DIFF
--- a/pkg/cmd/validate.go
+++ b/pkg/cmd/validate.go
@@ -10,8 +10,8 @@ import (
 
 var (
 	validateExample = `
-		# Print validate information
-		opencompose validate`
+  # Print validate information
+  opencompose validate`
 )
 
 func NewCmdValidate(v *viper.Viper, out, outerr io.Writer) *cobra.Command {

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -11,8 +11,8 @@ import (
 
 var (
 	versionExample = `
-		# Print version information
-		kubectl version`
+  # Print version information
+  kubectl version`
 )
 
 func NewCmdVersion(v *viper.Viper, out, outerr io.Writer) *cobra.Command {


### PR DESCRIPTION
We were using spaces and not tabs in some commands' help output.

Closes https://github.com/redhat-developer/opencompose/issues/38