### PR TITLE
Added support for providing replicas

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -7,12 +7,13 @@ version: "0.1-dev"
 
 services:
    name: foobar
+   replicas: 3
    containers:
    - image: foo/bar:tag
      env:
      - foo=bar
      command: ["/bin/foobar"]
-     args: 
+     args:
      - "-f"
      - "/tmp/foobar"
      ports:
@@ -25,7 +26,7 @@ OpenCompose file has two main sections *version* and *services*.
 
 ## version
 | type  | required |
-|-------|----------| 
+|-------|----------|
 |string |    yes   |
 
 Version of OpenCompose format.
@@ -35,14 +36,15 @@ Version of OpenCompose format.
 `services` has to be array of [ServiceSpec](#servicespec).
 
 ### ServiceSpec
-Describes one service. Service can be composed of one or multiple containers which are scheduled 
+Describes one service. Service can be composed of one or multiple containers which are scheduled
 together and can communicate using localhost. (Containers in the same service share network namespace.)
 
-Each service has name and list of the containers.
+Each service has name and list of the containers, while `replicas` can be optional.
 
 ```yml
 # <ServiceSpec>
   name: foo
+  replicas: 4
   containers:
   - <ContainerSpec>
 ```
@@ -54,9 +56,16 @@ Each service has name and list of the containers.
 
 Name of the service.
 
+#### replicas
+| type    | required |
+|---------|----------|
+| integer |    no    |
+
+Number of desired pods of this particluar service. This is an optional field. The valid value can only be a positive number.
+
 ### containers
 | type                                    | required |
-|-----------------------------------------|----------| 
+|-----------------------------------------|----------|
 |array of [ContainerSpec](#containerspec) |    yes   |
 
 Each item in [containers](#containers) ([ContainerSpec](#containerspec)) defines one container.
@@ -141,7 +150,7 @@ This defines what ports will be exposed for communication.
 
 ```
 
-#### port 
+#### port
 | type | required |
 |------|----------|
 |string|    yes   |
@@ -153,7 +162,7 @@ This is a string in following format: `ContainerPort:ServicePort`
 `ServicePort` is optional. It defaults to `ContainerPort` if not specified.
 
 
-#### type 
+#### type
 | type        | required | possible values         |
 |-------------|----------|-------------------------|
 |enum(string) |    no    | `internal` or `external`|
@@ -163,21 +172,21 @@ Default value for type is `internal`.
 - `internal` - port will be accessible only from inside the Kubernetes cluster
 - `external` - port will be accessible from inside and outside of the Kubernetes cluster
 
-#### host 
+#### host
 | type        | required | possible values                                           |
 |-------------|----------|-----------------------------------------------------------|
 | string      |    no    | FQDN (fully qualified domain name) as defined by RFC 3986 |
 
 Specifying host will make your application accessible outside of the cluster on domain specified as a value of `host`. (Note: this requires you to manually setup DNS records to point to your cluster's Ingress router. For development you can use services like http://nip.io/ or [http://xip.io/].)
 
-#### path 
+#### path
 | type        | required | possible values                                               |
 |-------------|----------|---------------------------------------------------------------|
 | string      |    no    | An extended POSIX regex as defined by IEEE Std 1003.1         |
 |             |          | (i.e this follows the egrep/unix syntax, not the perl syntax) |
 
 - If you don't specify a `path` it matches all request to `host`.
-- You have to specify `host` if you want to specify `path`.  
+- You have to specify `host` if you want to specify `path`.
 
 ##### Path Based Ingresses
 Path based ingresses specify a path component that can be compared against a URL (which requires that the traffic for the ingress be HTTP based) such that multiple ingresses can be served using the same host name, each with a different path. Ingress controller should match ingresses based on the most specific path to the least; however, this depends on the ingress controller implementation. The following table shows example ingresses and their accessibility:

--- a/pkg/cmd/convert.go
+++ b/pkg/cmd/convert.go
@@ -96,7 +96,9 @@ func GetValidatedObject(v *viper.Viper, cmd *cobra.Command, out, outerr io.Write
 	// FIXME: implement merging OpenCompose obejcts
 	openCompose := ocObjects[0]
 
-	openCompose.Validate()
+	if err := openCompose.Validate(); err != nil {
+		return nil, err
+	}
 
 	return openCompose, nil
 }

--- a/pkg/encoding/v1/encoding.go
+++ b/pkg/encoding/v1/encoding.go
@@ -208,6 +208,7 @@ func (c *Container) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Service struct {
 	Name       ResourceName `yaml:"name"`
 	Containers []Container  `yaml:"containers"`
+	Replicas   *int32       `yaml:"replicas,omitempty"`
 }
 
 func (s *Service) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -342,6 +343,8 @@ func (d *Decoder) Decode(data []byte) (*object.OpenCompose, error) {
 		os := object.Service{
 			Name: string(s.Name),
 		}
+
+		os.Replicas = s.Replicas
 
 		// convert containers
 		for _, c := range s.Containers {

--- a/pkg/goutil/goutil.go
+++ b/pkg/goutil/goutil.go
@@ -11,3 +11,7 @@ func StringOrEmpty(p *string) string {
 	}
 	return ""
 }
+
+func Int32Addr(i int32) *int32 {
+	return &i
+}

--- a/pkg/goutil/goutil_test.go
+++ b/pkg/goutil/goutil_test.go
@@ -24,3 +24,19 @@ func TestStringOrEmpty(t *testing.T) {
 		})
 	}
 }
+
+func TestInt32Addr(t *testing.T) {
+	tests := []struct {
+		input  int32
+		output *int32
+	}{
+		{1, Int32Addr(1)},
+		{2, Int32Addr(2)},
+	}
+
+	for _, test := range tests {
+		if test.input != *test.output {
+			t.Errorf("The input '%d' and output '%d' doesn't match.", test.input, test.output)
+		}
+	}
+}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -1,5 +1,7 @@
 package object
 
+import "fmt"
+
 type PortMapping struct {
 	ContainerPort int
 	ServicePort   int
@@ -33,6 +35,7 @@ type Container struct {
 type Service struct {
 	Name       string
 	Containers []Container
+	Replicas   *int32
 }
 
 type Volume struct {
@@ -47,9 +50,27 @@ type OpenCompose struct {
 	Volumes  []Volume
 }
 
+func (s *Service) Validate() error {
+	// validate service name, like it cannot have underscores, etc.
+
+	// validate containers
+
+	// validate replicas
+	if s.Replicas != nil && *s.Replicas < 0 {
+		return fmt.Errorf("Replica count is negative in service: %q", s.Name)
+	}
+
+	return nil
+}
+
 // Does high level (mostly semantic) validation of OpenCompose
 // (e.g. it checks internal object references)
 func (o *OpenCompose) Validate() error {
-	// TODO: implement
+	// validating services
+	for _, service := range o.Services {
+		if err := service.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -1,0 +1,111 @@
+package object
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/redhat-developer/opencompose/pkg/goutil"
+)
+
+const (
+	Version = "0.1-dev" // TODO: replace with "1" once we reach that point
+)
+
+func TestOpenCompose_Validate(t *testing.T) {
+	name := "test-service"
+	image := "test-image"
+
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		openCompose     *OpenCompose
+	}{
+		{
+			"Empty replica value",
+			true,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+							},
+						},
+						Replicas: nil,
+					},
+				},
+			},
+		},
+
+		{
+			"Valid replica value: 0",
+			true,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+							},
+						},
+						Replicas: goutil.Int32Addr(0),
+					},
+				},
+			},
+		},
+
+		{
+			"Valid replica value: 2",
+			true,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+							},
+						},
+						Replicas: goutil.Int32Addr(2),
+					},
+				},
+			},
+		},
+
+		{
+			"Valid replica value: -1",
+			false,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+							},
+						},
+						Replicas: goutil.Int32Addr(-1),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Running test: %q", test.Name), func(t *testing.T) {
+			err := test.openCompose.Validate()
+
+			if test.ExpectedSuccess && err != nil {
+				t.Errorf("Expected success but failed as: %v", err)
+			} else if !test.ExpectedSuccess && err == nil {
+				t.Error("Expected failure but passed.")
+			}
+		})
+	}
+}

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -167,6 +167,8 @@ func (t *Transformer) CreateDeployments(o *object.Service) ([]runtime.Object, er
 		},
 	}
 
+	d.Spec.Replicas = o.Replicas
+
 	for i, c := range o.Containers {
 		kc := api_v1.Container{
 			Name:  fmt.Sprintf("%s-%d", o.Name, i),


### PR DESCRIPTION
A user can now provide the number of replicas of the
service that are needed, using a field called `replicas`
in opencompose `service` section.

This is an optional field, if nothing is provided then
the value defaults to 1.

Fixes #19 