### PR TITLE
Fix generated file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ services:
 opencompose convert -f hello-nginx.yaml
 ```
 
-This will create two Kubernetes files in current directory - `deployment-helloworld.yaml` and `service-helloworld.yaml`.
+This will create two Kubernetes files in current directory - `helloworld-deployment.yaml` and `helloworld-service.yaml`.
 
 To deploy your application to Kubernetes run:
 
 ```sh
-kubectl create -f service-helloworld.yaml -f deployment-helloworld.yaml
+kubectl create -f helloworld-service.yaml -f helloworld-deployment.yaml
 ```
 
 

--- a/pkg/cmd/convert.go
+++ b/pkg/cmd/convert.go
@@ -133,7 +133,7 @@ func RunConvert(v *viper.Viper, cmd *cobra.Command, out, outerr io.Writer) error
 				return fmt.Errorf("failed to cast runtime.object to meta.object (type is %s): %s", reflect.TypeOf(o).String(), err)
 			}
 
-			filename := fmt.Sprintf("%s-%s.yaml", strings.ToLower(kind), m.GetName())
+			filename := fmt.Sprintf("%s-%s.yaml", m.GetName(), strings.ToLower(kind))
 			return ioutil.WriteFile(path.Join(outputDir, filename), data, 0644)
 		}
 	}


### PR DESCRIPTION
 Fix generated file names to <service_name>-<object_kind>.yaml (it used to be the other way around).

Fixes https://github.com/redhat-developer/opencompose/issues/58