### PR TITLE
Generate deployment only once

### DIFF
--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -127,9 +127,9 @@ func (t *Transformer) CreateDeployments(o *object.Service) ([]runtime.Object, er
 		}
 
 		d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, kc)
-
-		result = append(result, d)
 	}
+
+	result = append(result, d)
 
 	return result, nil
 }


### PR DESCRIPTION
Deployment was generated per container. This commit fixes that behavior and generates only one deployment.

This was not noticed before because in convert only files were generated so the extra file was over written.

Now with the new feature of showing output to STDOUT this issue was discovered.

Fixes #86