### PR TITLE
Add volumes implementation support

### DIFF
--- a/examples/wordpress/storage.yaml
+++ b/examples/wordpress/storage.yaml
@@ -1,0 +1,33 @@
+version: '0.1-dev'
+
+services:
+- name: database
+  containers:
+  - image: mariadb:10
+    env:
+      - MYSQL_ROOT_PASSWORD=rootpasswd
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD=wordpress
+    ports:
+    - port: 3306
+    mounts:
+    - volumeName: database
+      mountPath: /var/lib/mysql
+
+- name: web
+  containers:
+  - image: wordpress:4
+    env:
+    - WORDPRESS_DB_HOST=database:3306
+    - WORDPRESS_DB_PASSWORD=wordpress
+    - WORDPRESS_DB_USER=wordpress
+    - WORDPRESS_DB_NAME=wordpress
+    ports:
+    - port: 80
+      type: external
+
+volumes:
+- name: database
+  size: 100Mi
+  accessMode: ReadWriteOnce

--- a/pkg/goutil/goutil.go
+++ b/pkg/goutil/goutil.go
@@ -15,3 +15,7 @@ func StringOrEmpty(p *string) string {
 func Int32Addr(i int32) *int32 {
 	return &i
 }
+
+func BoolAddr(b bool) *bool {
+	return &b
+}

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -1,6 +1,15 @@
 package object
 
-import "fmt"
+import (
+	"fmt"
+
+	"strings"
+
+	"path"
+
+	"k8s.io/client-go/pkg/api/resource"
+	"k8s.io/client-go/pkg/util/validation"
+)
 
 type PortMapping struct {
 	ContainerPort int
@@ -26,22 +35,36 @@ type EnvVariable struct {
 	Value string
 }
 
+type Mount struct {
+	VolumeName    string
+	MountPath     string
+	VolumeSubPath string
+	ReadOnly      bool
+}
+
 type Container struct {
 	Image       string
 	Environment []EnvVariable
 	Ports       []Port
+	Mounts      []Mount
+}
+
+type EmptyDirVolume struct {
+	Name string
 }
 
 type Service struct {
-	Name       string
-	Containers []Container
-	Replicas   *int32
+	Name            string
+	Containers      []Container
+	Replicas        *int32
+	EmptyDirVolumes []EmptyDirVolume
 }
 
 type Volume struct {
-	Name string
-	Size string
-	Mode string
+	Name         string
+	Size         string
+	AccessMode   string
+	StorageClass *string
 }
 
 type OpenCompose struct {
@@ -50,14 +73,128 @@ type OpenCompose struct {
 	Volumes  []Volume
 }
 
-func (s *Service) Validate() error {
+// Given the name of 'emptyDirVolume' this function searches
+// if service receiver has that 'emptyDirVolume'
+func (s *Service) EmptyDirVolumeExists(name string) bool {
+	for _, emptyDirVolume := range s.EmptyDirVolumes {
+		if name == emptyDirVolume.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// Given name of root level 'volume' this function searches
+// if opencompose receiver has that 'volume'.
+func (o *OpenCompose) VolumeExists(name string) bool {
+	for _, volume := range o.Volumes {
+		if name == volume.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// Documentation about the valid identifiers can be found at
+// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md
+func validateName(name string) error {
+	if errs := validation.IsDNS1123Subdomain(name); len(errs) != 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func (c *Container) validate() error {
+
+	// validate image name
+	// TODO: implement me
+	// validate Environment
+	// TODO: implement me
+	// validate Ports
+	// TODO: implement me
+
+	allMounts := make(map[string]string)
+	// validate Mounts
+	for _, mount := range c.Mounts {
+		// validate volumeName
+		if err := validateName(mount.VolumeName); err != nil {
+			return fmt.Errorf("mount %q: invalid name, %v", mount.VolumeName, err)
+		}
+
+		// mountPath should be absolute
+		if !path.IsAbs(mount.MountPath) {
+			return fmt.Errorf("mount %q: mountPath %q: is not absolute path", mount.VolumeName, mount.MountPath)
+		}
+		// mountPath should not collide, which means you should not do multiple mounts in same place
+		if v, ok := allMounts[mount.MountPath]; ok {
+			return fmt.Errorf("mount %q: mountPath %q: cannot have same mountPath as %q", mount.VolumeName, mount.MountPath, v)
+		}
+		allMounts[mount.MountPath] = mount.VolumeName
+
+		// validate volumeSubPath
+		// TODO: if there is someway to do it
+	}
+
+	return nil
+}
+
+func (s *Service) validate() error {
 	// validate service name, like it cannot have underscores, etc.
+	if err := validateName(s.Name); err != nil {
+		return fmt.Errorf("invalid name, %v", err)
+	}
 
 	// validate containers
+	for cno, cnt := range s.Containers {
+		if err := cnt.validate(); err != nil {
+			return fmt.Errorf("container#%d: %v", cno+1, err)
+		}
+	}
 
 	// validate replicas
 	if s.Replicas != nil && *s.Replicas < 0 {
-		return fmt.Errorf("Replica count is negative in service: %q", s.Name)
+		return fmt.Errorf("%s", "'replicas' can't be negative")
+	}
+
+	// validate emptyDirVolume
+	for _, e := range s.EmptyDirVolumes {
+		if err := validateName(e.Name); err != nil {
+			return fmt.Errorf("emptyDirVolume %q: invalid name, %v", e.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func validateVolumeMode(volumeMode string) error {
+	switch volumeMode {
+	case "ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany":
+	default:
+		return fmt.Errorf("invalid accessMode: %q, must be either %q, %q or %q", volumeMode, "ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany")
+	}
+	return nil
+}
+
+func (v *Volume) validate() error {
+	// validate volume name
+	if err := validateName(v.Name); err != nil {
+		return fmt.Errorf("invalid name, %v", err)
+	}
+
+	// validate volume size
+	if _, err := resource.ParseQuantity(v.Size); err != nil {
+		return fmt.Errorf("size %q: %v", v.Size, err)
+	}
+
+	// validate volume access mode
+	if err := validateVolumeMode(v.AccessMode); err != nil {
+		return err
+	}
+
+	if v.StorageClass != nil {
+		if err := validateName(*v.StorageClass); err != nil {
+			return fmt.Errorf("storageClass %q: invalid name, %v", *v.StorageClass, err)
+		}
 	}
 
 	return nil
@@ -68,9 +205,28 @@ func (s *Service) Validate() error {
 func (o *OpenCompose) Validate() error {
 	// validating services
 	for _, service := range o.Services {
-		if err := service.Validate(); err != nil {
-			return err
+		if err := service.validate(); err != nil {
+			return fmt.Errorf("service %q: %v", service.Name, err)
+		}
+
+		// validate if the mounts are specified in root level volumes
+		// or emptydirvolumes, error out if not found anywhere
+		for cno, container := range service.Containers {
+			for _, mount := range container.Mounts {
+				if !o.VolumeExists(mount.VolumeName) && !service.EmptyDirVolumeExists(mount.VolumeName) {
+					return fmt.Errorf("volume mount %q in service %q in container#%d does not correspond to either 'root level volume' or 'emptydir volume'",
+						mount.VolumeName, service.Name, cno+1)
+				}
+			}
 		}
 	}
+
+	// validate volumes
+	for _, volume := range o.Volumes {
+		if err := volume.validate(); err != nil {
+			return fmt.Errorf("volume %q: %v", volume.Name, err)
+		}
+	}
+
 	return nil
 }

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -11,6 +11,296 @@ const (
 	Version = "0.1-dev" // TODO: replace with "1" once we reach that point
 )
 
+func TestService_EmptyDirVolumeExists(t *testing.T) {
+	tests := []struct {
+		ExpectedSuccess bool
+		Search          string
+		Service         *Service
+	}{
+		{
+			true,
+			"foo",
+			&Service{
+				EmptyDirVolumes: []EmptyDirVolume{
+					{Name: "one"},
+					{Name: "two"},
+					{Name: "three"},
+					{Name: "foo"},
+				},
+			},
+		},
+		{
+			false,
+			"foo",
+			&Service{
+				EmptyDirVolumes: []EmptyDirVolume{
+					{Name: "one"},
+					{Name: "two"},
+					{Name: "three"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		output := test.Service.EmptyDirVolumeExists(test.Search)
+		if output != test.ExpectedSuccess {
+			t.Errorf("Expected output: %v but got: %v, for searching %q in emptyDirVolume: %+v", test.ExpectedSuccess, output, test.Search, test.Service.EmptyDirVolumes)
+		}
+	}
+}
+
+func TestOpenCompose_VolumeExists(t *testing.T) {
+	tests := []struct {
+		ExpectedSuccess bool
+		Search          string
+		OpenCompose     *OpenCompose
+	}{
+		{
+			true,
+			"foo",
+			&OpenCompose{
+				Volumes: []Volume{
+					{Name: "one"},
+					{Name: "two"},
+					{Name: "three"},
+					{Name: "foo"},
+				},
+			},
+		},
+		{
+			false,
+			"foo",
+			&OpenCompose{
+				Volumes: []Volume{
+					{Name: "one"},
+					{Name: "two"},
+					{Name: "three"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		output := test.OpenCompose.VolumeExists(test.Search)
+		if output != test.ExpectedSuccess {
+			t.Errorf("Expected output: %v but got: %v, for searching %q in volumes: %+v", test.ExpectedSuccess, output, test.Search, test.OpenCompose.Volumes)
+		}
+	}
+}
+
+func TestContainer_Validate(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Container       *Container
+	}{
+		{
+			"invalid mount name",
+			false,
+			&Container{
+				Mounts: []Mount{
+					{
+						VolumeName: "invalid_mount_name",
+					},
+				},
+			},
+		},
+		{
+			"mountPath not absolute",
+			false,
+			&Container{
+				Mounts: []Mount{
+					{
+						VolumeName: "test",
+						MountPath:  "foo/bar",
+					},
+				},
+			},
+		},
+		{
+			"same mountPath in multiple mounts",
+			false,
+			&Container{
+				Mounts: []Mount{
+					{
+						VolumeName: "test1",
+						MountPath:  "/foo/bar",
+					},
+					{
+						VolumeName: "test2",
+						MountPath:  "/foo/bar",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := test.Container.validate()
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestService_Validate(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Service         *Service
+	}{
+		{
+			"invalid name of service",
+			false,
+			&Service{
+				Name: "foo_bar",
+			},
+		},
+		{
+			"negative replica count",
+			false,
+			&Service{
+				Name:     "test",
+				Replicas: goutil.Int32Addr(-2),
+			},
+		},
+		{
+			"invalid emptyDirVolume name",
+			false,
+			&Service{
+				Name: "test",
+				EmptyDirVolumes: []EmptyDirVolume{
+					{Name: "foo_bar"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := test.Service.validate()
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateVolumeMode(t *testing.T) {
+	tests := []struct {
+		ExpectedSuccess bool
+		Input           string
+	}{
+		{true, "ReadWriteOnce"},
+		{true, "ReadOnlyMany"},
+		{true, "ReadWriteMany"},
+		{false, "foo"},
+	}
+
+	for _, test := range tests {
+		err := validateVolumeMode(test.Input)
+		if err != nil && test.ExpectedSuccess {
+			t.Errorf("Expected success but failed with error: %v", err)
+		} else if err == nil && !test.ExpectedSuccess {
+			t.Error("Expected to fail but passed.")
+		}
+	}
+}
+
+func TestVolume_Validate(t *testing.T) {
+
+	storageClass := "fast"
+	invalidStorageClass := "foo_foo"
+
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Volume          *Volume
+	}{
+		{
+			"All fields given as valid input",
+			true,
+			&Volume{
+				Name:         "testvol",
+				Size:         "5Gi",
+				AccessMode:   "ReadWriteMany",
+				StorageClass: &storageClass,
+			},
+		},
+
+		{
+			"Invalid volume name given, should fail",
+			false,
+			&Volume{
+				Name: "test_vol",
+			},
+		},
+
+		{
+			"Invalid volume size, should fail",
+			false,
+			&Volume{
+				Name: "testvol",
+				Size: "5foo",
+			},
+		},
+
+		{
+			"Invalid volume access mode, should fail",
+			false,
+			&Volume{
+				Name:       "testsvol",
+				Size:       "5Gi",
+				AccessMode: "foo",
+			},
+		},
+
+		{
+			"Invalid volume storage class, should fail",
+			false,
+			&Volume{
+				Name:         "testsvol",
+				Size:         "5Gi",
+				AccessMode:   "ReadWriteMany",
+				StorageClass: &invalidStorageClass,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := test.Volume.validate()
+			if test.ExpectedSuccess && err != nil {
+				// failing condition
+				t.Fatalf("Expected success but failed as: %v", err)
+			} else if !test.ExpectedSuccess && err == nil {
+				// failing condition
+				t.Fatal("Expected failure but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
 func TestOpenCompose_Validate(t *testing.T) {
 	name := "test-service"
 	image := "test-image"


### PR DESCRIPTION
This PR adds support for volumes in OpenCompose.

With this there is new root level directive called `volumes` and new directive in container level called
`mounts` and also adds service level directive called `emptyDirVolumes`.

More info about volumes is in the proposal: https://github.com/surajssd/opencompose/blob/22207ea605580d70c6718fa87368d0385bc3cbf0/docs/proposals/volumes-proposal.md

Fixes #25