### PR TITLE
Show failure cause for tests expected to fail

### DIFF
--- a/pkg/encoding/util/util_test.go
+++ b/pkg/encoding/util/util_test.go
@@ -126,6 +126,7 @@ func TestValidateRequiredFields(t *testing.T) {
 			if tt.Succeed {
 				t.Errorf("Failed to validate %#v: %s", tt.Value, err)
 			}
+			t.Logf("Expected failure and failed with err: %v", err)
 			continue
 		}
 

--- a/pkg/encoding/v1/encoding_test.go
+++ b/pkg/encoding/v1/encoding_test.go
@@ -59,6 +59,7 @@ func TestPortMapping_UnmarshalYAML(t *testing.T) {
 			if tt.Succeed {
 				t.Errorf("Failed to unmarshal %q: %s", tt.RawPort, err)
 			}
+			t.Logf("Expected failure and failed with err: %v", err)
 			continue
 		}
 
@@ -101,6 +102,7 @@ func TestPortType_UnmarshalYAML(t *testing.T) {
 			if tt.Succeed {
 				t.Errorf("Failed to unmarshal port type %q: %s", tt.RawPortType, err)
 			}
+			t.Logf("Expected failure and failed with err: %v", err)
 			continue
 		}
 
@@ -212,6 +214,7 @@ path: "/admin"
 				if tt.Succeed {
 					t.Fatalf("Failed to unmarshal port %q: %s", tt.RawPort, err)
 				}
+				t.Logf("Expected failure and failed with err: %v", err)
 				return
 			}
 
@@ -250,6 +253,7 @@ func TestEnvVariable_UnmarshalYAML(t *testing.T) {
 			if tt.Succeed {
 				t.Errorf("Failed to unmarshal %#v; error %#v", tt.RawEnvVar, err)
 			}
+			t.Logf("Expected failure and failed with err: %v", err)
 			continue
 		}
 
@@ -545,12 +549,12 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
-	env:
-	- KEY=value
-	- KEY2=value2
-	ports:
-	- port: 5000:80
-	- port: 5001:81
+    env:
+    - KEY=value
+    - KEY2=value2
+    ports:
+    - port: 5000:80
+    - port: 5001:81
 volumes:
 - name: data
   size: 1Gi
@@ -668,6 +672,7 @@ services:
 				if tt.Succeed {
 					t.Fatalf("Failed to unmarshal %#v; error %#v", tt.File, err)
 				}
+				t.Logf("Expected failure and failed with err: %v", err)
 				return
 			}
 

--- a/pkg/transform/kubernetes/kubernetes_test.go
+++ b/pkg/transform/kubernetes/kubernetes_test.go
@@ -337,6 +337,7 @@ func TestTransformer_CreateServices(t *testing.T) {
 			if tt.Succeed {
 				t.Errorf("Failed to create services from %+v: %s", tt.Service, err)
 			}
+			t.Logf("Expected failure and failed with err: %v", err)
 			continue
 		}
 
@@ -563,6 +564,7 @@ func TestTransformer_CreateIngresses(t *testing.T) {
 				if tt.Succeed {
 					t.Fatalf("Failed to create ingresses from %+v: %s", tt.Service, err)
 				}
+				t.Logf("Expected failure and failed with err: %v", err)
 				return
 			}
 


### PR DESCRIPTION
We have tests which are expected to fail, defined alongside the tests that are meant to pass and this is only checked with a flag defined in the test itself.

So when a test is meant to fail, we just see if the testable funtion is returning error and have no idea if the error is the one we wanted to see.

Hence add a log statement to see if test fails for the reason we want & not something else.