### PR TITLE
fix indentation in wordpress examples for env

### DIFF
--- a/examples/wordpress/no-storage.yaml
+++ b/examples/wordpress/no-storage.yaml
@@ -5,10 +5,10 @@ services:
   containers:
   - image: mariadb:10
     env:
-      - MYSQL_ROOT_PASSWORD=rootpasswd
-      - MYSQL_DATABASE=wordpress
-      - MYSQL_USER=wordpress
-      - MYSQL_PASSWORD=wordpress
+    - MYSQL_ROOT_PASSWORD=rootpasswd
+    - MYSQL_DATABASE=wordpress
+    - MYSQL_USER=wordpress
+    - MYSQL_PASSWORD=wordpress
     ports:
     - port: 3306
 

--- a/examples/wordpress/storage.yaml
+++ b/examples/wordpress/storage.yaml
@@ -5,10 +5,10 @@ services:
   containers:
   - image: mariadb:10
     env:
-      - MYSQL_ROOT_PASSWORD=rootpasswd
-      - MYSQL_DATABASE=wordpress
-      - MYSQL_USER=wordpress
-      - MYSQL_PASSWORD=wordpress
+    - MYSQL_ROOT_PASSWORD=rootpasswd
+    - MYSQL_DATABASE=wordpress
+    - MYSQL_USER=wordpress
+    - MYSQL_PASSWORD=wordpress
     ports:
     - port: 3306
     mounts:


### PR DESCRIPTION
Indentation was a bit off for wordpress examples
in the environment variables defition, from the
rest of the file.

This commit fixes it.