### PR TITLE
refactor env definition from a=b to name: a,value: b

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -11,7 +11,8 @@ services:
   containers:
   - image: foo/bar:tag
     env:
-    - foo=bar
+    - name: foo
+      value: bar
     command: ["/bin/foobar"]
     args:
     - "-f"
@@ -98,7 +99,8 @@ These volumes will be shared among the containers in the service.
 # <ContainerSpec>
   image: foo/bar:tag
   env:
-  - VARIABLE=value
+  - name: VARIABLE
+    value: value
   command:
     - /foo/bar
   args:
@@ -121,7 +123,7 @@ Name of the image that container will be started from.
 #### env
 | type            | required |
 |-----------------|----------|
-|array of strings |    no    |
+|array of [EnvSpec](#envspec) |    no    |
 
 List of environment variables to set in the container.
 Each string has to be formated as `variable_name=value`.
@@ -170,6 +172,30 @@ This defines what ports will be exposed for communication.
 
 This defines what volumes will be mounted inside the container.
 
+
+### EnvSpec
+```yml
+# <EnvSpec>
+  name: DB_USER
+  value: bob
+```
+
+Inside the containers, the environment variables will generally be visible as,
+DB_USER=bob
+
+#### name
+| type | required |
+|------|----------|
+|string|    yes   |
+
+This is a string which defines the name of the environment variable being set.
+
+#### value
+| type | required |
+|------|----------|
+|string|    yes   |
+
+This is string which defines the value of the environment variable being set.
 
 ### PortSpec
 ```yml

--- a/examples/wordpress/no-storage.yaml
+++ b/examples/wordpress/no-storage.yaml
@@ -5,10 +5,14 @@ services:
   containers:
   - image: mariadb:10
     env:
-    - MYSQL_ROOT_PASSWORD=rootpasswd
-    - MYSQL_DATABASE=wordpress
-    - MYSQL_USER=wordpress
-    - MYSQL_PASSWORD=wordpress
+    - name: MYSQL_ROOT_PASSWORD
+      value: rootpasswd
+    - name: MYSQL_DATABASE
+      value: wordpress
+    - name: MYSQL_USER
+      value: wordpress
+    - name: MYSQL_PASSWORD
+      value: wordpress
     ports:
     - port: 3306
 
@@ -16,10 +20,14 @@ services:
   containers:
   - image: wordpress:4
     env:
-    - WORDPRESS_DB_HOST=database:3306
-    - WORDPRESS_DB_PASSWORD=wordpress
-    - WORDPRESS_DB_USER=wordpress
-    - WORDPRESS_DB_NAME=wordpress
+    - name: WORDPRESS_DB_HOST
+      value: database:3306
+    - name: WORDPRESS_DB_PASSWORD
+      value: wordpress
+    - name: WORDPRESS_DB_USER
+      value: wordpress
+    - name: WORDPRESS_DB_NAME
+      value: wordpress
     ports:
     - port: 80
       type: external

--- a/examples/wordpress/storage.yaml
+++ b/examples/wordpress/storage.yaml
@@ -5,10 +5,14 @@ services:
   containers:
   - image: mariadb:10
     env:
-    - MYSQL_ROOT_PASSWORD=rootpasswd
-    - MYSQL_DATABASE=wordpress
-    - MYSQL_USER=wordpress
-    - MYSQL_PASSWORD=wordpress
+    - name: MYSQL_ROOT_PASSWORD
+      value: rootpasswd
+    - name: MYSQL_DATABASE
+      value: wordpress
+    - name: MYSQL_USER
+      value: wordpress
+    - name: MYSQL_PASSWORD
+      value: wordpress
     ports:
     - port: 3306
     mounts:
@@ -19,10 +23,14 @@ services:
   containers:
   - image: wordpress:4
     env:
-    - WORDPRESS_DB_HOST=database:3306
-    - WORDPRESS_DB_PASSWORD=wordpress
-    - WORDPRESS_DB_USER=wordpress
-    - WORDPRESS_DB_NAME=wordpress
+    - name: WORDPRESS_DB_HOST
+      value: database:3306
+    - name: WORDPRESS_DB_PASSWORD
+      value: wordpress
+    - name: WORDPRESS_DB_USER
+      value: wordpress
+    - name: WORDPRESS_DB_NAME
+      value: wordpress
     ports:
     - port: 80
       type: external

--- a/pkg/encoding/v1/encoding_test.go
+++ b/pkg/encoding/v1/encoding_test.go
@@ -232,15 +232,47 @@ func TestEnvVariable_UnmarshalYAML(t *testing.T) {
 		RawEnvVar string
 		EnvVar    *EnvVariable
 	}{
-		{true, "'KEY=value string '", &EnvVariable{Key: "KEY", Value: "value string "}},
-		{true, "KEY= value", &EnvVariable{Key: "KEY", Value: " value"}},
-		{true, "KEY =value", &EnvVariable{Key: "KEY", Value: "value"}},
-		{true, "KEY==value", &EnvVariable{Key: "KEY", Value: "=value"}},
-		{true, "KEY=", &EnvVariable{Key: "KEY", Value: ""}},
-		{false, "KEY", nil},
-		{false, "=KEYvalue", nil},
-		{false, "=KEY=value", nil},
-		{false, "=KEY=value=", nil},
+		{
+			true,
+			`
+name: "KEY"
+value: "value string "
+`,
+			&EnvVariable{Key: "KEY", Value: "value string "},
+		},
+		{
+			true,
+			`
+name: "KEY"
+value: " value"
+`,
+			&EnvVariable{Key: "KEY", Value: " value"},
+		},
+		{
+			true,
+			`
+name: " KEY"
+value: "value"
+`,
+			&EnvVariable{Key: " KEY", Value: "value"},
+		},
+
+		{
+			true,
+			`
+name: KEY
+value: ""
+`,
+			&EnvVariable{Key: "KEY", Value: ""},
+		},
+		{
+			false,
+			`
+name: KEY
+key: extra_field
+`,
+			nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -631,8 +663,10 @@ services:
   containers:
   - image: tomaskral/kompose-demo-frontend:test
     env:
-    - KEY=value
-    - KEY2=value2
+    - name: KEY
+      value: value
+    - name: KEY2
+      value: value2
     ports:
     - port: 5000:80
     - port: 5001:81
@@ -822,8 +856,10 @@ services:
   containers:
   - image: tomaskral/kompose-demo-frontend:test
     env:
-    - KEY=value
-    - KEY2=value2
+	- name: KEY
+	  value: value
+	- name: KEY2
+	  value: value2
     ports:
     - port: 5000:80
     - port: 5001:81
@@ -839,8 +875,10 @@ services:
   containers:
   - image: tomaskral/kompose-demo-frontend:test
 	env:
-	- KEY=value
-	- KEY2=value2
+	- name: KEY
+	  value: value
+	- name: KEY2
+	  value: value2
 	ports:
 	- port: 5000:80
 	- port: 5001:81
@@ -849,6 +887,64 @@ volumes:
   size: 1Gi
   mode: ReadWriteOnce
   EXCESSKEY: some value
+`,
+			nil,
+		},
+		{
+			false, `
+version: 0.1-dev
+services:
+- name: frontend
+  containers:
+  - image: tomaskral/kompose-demo-frontend:test
+    env:
+    - name: KEY
+      value: value
+    - name: KEY2
+`,
+			nil,
+		},
+		{
+			false, `
+version: 0.1-dev
+services:
+- name: frontend
+  containers:
+  - image: tomaskral/kompose-demo-frontend:test
+    env:
+    - name: KEY
+      value: value
+    - value: value
+`,
+			nil,
+		},
+		{
+			false, `
+version: 0.1-dev
+services:
+- name: frontend
+  containers:
+  - image: tomaskral/kompose-demo-frontend:test
+    env:
+    - name: KEY
+      value: value
+    - name:
+      value: value
+`,
+			nil,
+		},
+		{
+			false, `
+version: 0.1-dev
+services:
+- name: frontend
+  containers:
+  - image: tomaskral/kompose-demo-frontend:test
+    env:
+    - name: KEY
+      value: value
+    - name: KEY2
+      value:
 `,
 			nil,
 		},
@@ -869,8 +965,10 @@ services:
   containers:
   - image: tomaskral/kompose-demo-frontend:test
     env:
-    - KEY=value
-    - KEY2=value2
+    - name: KEY
+      value: value
+    - name: KEY2
+      value: value2
     ports:
     - port: 5000:80
     - port: 5001:81


### PR DESCRIPTION
The environment variables have been declared in OpenCompose till
now as -

env:
- a=b
- x=y

This is essentially a list of strings, and this made it very
difficult to extend the environment variable definition with
other concepts like secrets, etc.

This commit changes the environment variable definition to -
env:
- name: a
  value: b
- name: x
  value: y

Also, this -
- fixes tests that were breaking
- removes tests which are not relevant anymore, e.g. the ones
  which checked if multiple "=" broke the environment variable
  unmarshalling or not
- adds tests which make sure the name: and value: are both
  required fields, and that they cannot be left blank
- does not add validation for environment variables being passed
- fix examples which had env: definitions in them
- fix file-reference.md to include the newer env: definition

fixes #118