### PR TITLE
add validation for environment variables

### DIFF
--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -107,14 +107,30 @@ func validateName(name string) error {
 	return nil
 }
 
+func (e *EnvVariable) validate() error {
+	// TODO: add more validation tests besides checking for '='
+	if strings.Contains(e.Key, "=") {
+		return fmt.Errorf("Illegal character '=' in environment variable key: %v", e.Key)
+	}
+
+	if strings.Contains(e.Value, "=") {
+		return fmt.Errorf("Illegal character '=' in environment variable value: %v", e.Value)
+	}
+	return nil
+}
+
 func (c *Container) validate() error {
 
 	// validate image name
 	// TODO: implement me
-	// validate Environment
-	// TODO: implement me
 	// validate Ports
 	// TODO: implement me
+
+	for _, env := range c.Environment {
+		if err := env.validate(); err != nil {
+			return fmt.Errorf("failed to validate environment variable: %v", err)
+		}
+	}
 
 	allMounts := make(map[string]string)
 	// validate Mounts

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -134,6 +134,42 @@ func TestContainer_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			"passing '=' in environment variable key",
+			false,
+			&Container{
+				Environment: []EnvVariable{
+					{
+						Key:   "ke=y",
+						Value: "value",
+					},
+				},
+			},
+		},
+		{
+			"passing '=' in environment variable value",
+			false,
+			&Container{
+				Environment: []EnvVariable{
+					{
+						Key:   "key",
+						Value: "va=lue",
+					},
+				},
+			},
+		},
+		{
+			"passing a valid environment variable",
+			true,
+			&Container{
+				Environment: []EnvVariable{
+					{
+						Key:   "key",
+						Value: "value",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This commit adds validation in object.go for environment variables.
Currently, the only validation that is being added is to check for
the presence of "=" in either environment variable key or value,
and if found, then error out.

This is only going to validate the environment variables passed in
the OpenCompose file, not as per Kubernetes validations, which
should be added in kubernetes.go which is being tracked in #139