### PR TITLE
feat(spec): add support for health

### DIFF
--- a/examples/wordpress/health.yaml
+++ b/examples/wordpress/health.yaml
@@ -1,0 +1,69 @@
+version: '0.1-dev'
+
+services:
+- name: database
+  containers:
+  - image: mariadb:10
+    env:
+    - name: MYSQL_ROOT_PASSWORD
+      value: rootpasswd
+    - name: MYSQL_DATABASE
+      value: wordpress
+    - name: MYSQL_USER
+      value: wordpress
+    - name: MYSQL_PASSWORD
+      value: wordpress
+    ports:
+    - port: 3306
+    mounts:
+    - volumeRef: database
+      mountPath: /var/lib/mysql
+    health:
+      livenessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+        initialDelaySeconds: 30
+        timeoutSeconds: 5
+      readinessProbe:
+        exec:
+          command:
+          - mysqladmin
+          - ping
+        initialDelaySeconds: 5
+        timeoutSeconds: 1
+
+- name: web
+  containers:
+  - image: wordpress:4
+    env:
+    - name: WORDPRESS_DB_HOST
+      value: database:3306
+    - name: WORDPRESS_DB_PASSWORD
+      value: wordpress
+    - name: WORDPRESS_DB_USER
+      value: wordpress
+    - name: WORDPRESS_DB_NAME
+      value: wordpress
+    ports:
+    - port: 80
+      type: external
+    health:
+      livenessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 120
+        timeoutSeconds: 5
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 5
+        timeoutSeconds: 1
+
+volumes:
+- name: database
+  size: 100Mi
+  accessMode: ReadWriteOnce

--- a/pkg/encoding/util/util.go
+++ b/pkg/encoding/util/util.go
@@ -122,3 +122,23 @@ func ValidateRequiredFields(i interface{}) error {
 
 	return nil
 }
+
+// Converts the yaml read into empty interface to JSONified
+// empty interface, this can be used to marshal into actual
+// JSON and from there if you want it you can read it into
+// Took help from https://stackoverflow.com/a/40737676/3848679
+func InterfaceToJSON(i interface{}) interface{} {
+	switch x := i.(type) {
+	case map[interface{}]interface{}:
+		m2 := map[string]interface{}{}
+		for k, v := range x {
+			m2[k.(string)] = InterfaceToJSON(v)
+		}
+		return m2
+	case []interface{}:
+		for i, v := range x {
+			x[i] = InterfaceToJSON(v)
+		}
+	}
+	return i
+}

--- a/pkg/encoding/v1/encoding.go
+++ b/pkg/encoding/v1/encoding.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -10,6 +11,8 @@ import (
 	"github.com/redhat-developer/opencompose/pkg/goutil"
 	"github.com/redhat-developer/opencompose/pkg/object"
 	"gopkg.in/yaml.v2"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -219,11 +222,85 @@ func (m *Mount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+type Health struct {
+	// Data holder for ReadinessProbe while parsing
+	// Data from the yaml file will be read into this field
+	ReadinessProbeData interface{} `yaml:"readinessProbe,omitempty"`
+	// After certain processing the data in ReadinessProbeData
+	// will be populated into ReadinessProbe for further use
+	ReadinessProbe *api_v1.Probe
+
+	LivenessProbeData interface{} `yaml:"livenessProbe,omitempty"`
+	LivenessProbe     *api_v1.Probe
+}
+
+// If given an interface which has JSONified data of type Probe
+// this function will read the interface and give concrete
+// data strcuture pointer.
+func interfaceToProbe(i interface{}) (*api_v1.Probe, error) {
+	i = util.InterfaceToJSON(i)
+
+	var b []byte
+	var err error
+	if b, err = json.Marshal(i); err != nil {
+		return nil, fmt.Errorf("error: marshalling interface to bytes: %v", err)
+	}
+	var p api_v1.Probe
+	if err = json.Unmarshal(b, &p); err != nil {
+		return nil, fmt.Errorf("error: unmarshalling bytes to Probe: %v", err)
+	}
+	return &p, nil
+}
+
+func (h *Health) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type HealthAlias Health
+	var st struct {
+		HealthAlias `yaml:",inline"`
+		Leftovers   map[string]interface{} `yaml:",inline"` // Catches all undefined fields and must be empty after parsing.
+	}
+
+	err := unmarshal(&st)
+	if err != nil {
+		return err
+	}
+
+	if len(st.Leftovers) > 0 {
+		return util.NewExcessKeysErrorFromMap("Health", st.Leftovers)
+	}
+
+	*h = Health(st.HealthAlias)
+
+	// extract the data from interface into concrete data type 'Probe'
+	if h.ReadinessProbeData != nil {
+		h.ReadinessProbe, err = interfaceToProbe(h.ReadinessProbeData)
+		if err != nil {
+			return fmt.Errorf("readinessProbe: %v", err)
+		}
+		h.ReadinessProbeData = interface{}(nil)
+	}
+
+	// extract the data from interface into concrete data type 'Probe'
+	if h.LivenessProbeData != nil {
+		h.LivenessProbe, err = interfaceToProbe(h.LivenessProbeData)
+		if err != nil {
+			return fmt.Errorf("livenessProbe: %v", err)
+		}
+		h.LivenessProbeData = interface{}(nil)
+	}
+
+	// TODO: Right now we have no way of finding if the excess keys are given
+	// by the user, since we are doing the whole conversion from YAML to JSON
+	// and then parsing it into the internal k8s structs
+
+	return nil
+}
+
 type Container struct {
 	Image  ImageRef      `yaml:"image"`
 	Env    []EnvVariable `yaml:"env,omitempty"`
 	Ports  []Port        `yaml:"ports,omitempty"`
 	Mounts []Mount       `yaml:"mounts,omitempty"`
+	Health *Health       `yaml:"health,omitempty"`
 }
 
 func (c *Container) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -441,6 +518,11 @@ func (d *Decoder) Decode(data []byte) (*object.OpenCompose, error) {
 				}
 
 				oc.Mounts = append(oc.Mounts, mount)
+			}
+
+			if c.Health != nil {
+				oc.Health.LivenessProbe = c.Health.LivenessProbe
+				oc.Health.ReadinessProbe = c.Health.ReadinessProbe
 			}
 
 			// convert env

--- a/pkg/encoding/v1/encoding_test.go
+++ b/pkg/encoding/v1/encoding_test.go
@@ -9,6 +9,10 @@ import (
 	"github.com/redhat-developer/opencompose/pkg/goutil"
 	"github.com/redhat-developer/opencompose/pkg/object"
 	"gopkg.in/yaml.v2"
+
+	"k8s.io/client-go/pkg/util/intstr"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 func UriAddrFromString(s string) *Fqdn {
@@ -412,6 +416,251 @@ readOnly: true
 	}
 }
 
+func TestInterfaceToProbe(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Succeed  bool
+		RawProbe string
+		Probe    *api_v1.Probe
+	}{
+		{
+			"Probe with exec",
+			true, `
+exec:
+  command:
+  - cat
+  - /tmp/healthy
+initialDelaySeconds: 5
+periodSeconds: 5`,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					Exec: &api_v1.ExecAction{
+						Command: []string{"cat", "/tmp/healthy"},
+					},
+				},
+				InitialDelaySeconds: 5,
+				PeriodSeconds:       5,
+			},
+		},
+		{
+			"Probe with httpGet",
+			true, `
+httpGet:
+  scheme: HTTP`,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					HTTPGet: &api_v1.HTTPGetAction{
+						Scheme: api_v1.URISchemeHTTP,
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var input interface{}
+			err := yaml.Unmarshal([]byte(test.RawProbe), &input)
+			if err != nil {
+				t.Fatalf("error unmarshalling input to interface: %v", err)
+			}
+
+			gotProbe, err := interfaceToProbe(input)
+			if err != nil {
+				if test.Succeed {
+					t.Errorf("failed to convert raw interface: %q to Probe, error: %v\n", test.RawProbe, err)
+				}
+				return
+			}
+
+			if !test.Succeed {
+				t.Fatalf("expected %q to fail, but succeeded! Probe object looks like: %s", test.RawProbe, spew.Sprint(gotProbe))
+			}
+
+			if !reflect.DeepEqual(test.Probe, gotProbe) {
+				t.Fatalf("expected %#v\ngot %#v", spew.Sprint(test.Probe), spew.Sprint(gotProbe))
+			}
+
+		})
+
+	}
+}
+
+func TestHealth_UnmarshalYAML(t *testing.T) {
+
+	tests := []struct {
+		Name      string
+		Succeed   bool
+		RawHealth string
+		Health    *Health
+	}{
+		{
+			"Given all fields1",
+			true, `
+livenessProbe:
+  exec:
+    command:
+    - cat
+    - /tmp/healthy
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 1
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+    httpHeaders:
+    - name: X-Custom-Header
+      value: Awesome
+  initialDelaySeconds: 3
+  periodSeconds: 3`,
+			&Health{
+				LivenessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{
+							Command: []string{"cat", "/tmp/healthy"},
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       5,
+					TimeoutSeconds:      1,
+				},
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+							Path: "/healthz",
+							Port: intstr.FromInt(8080),
+							HTTPHeaders: []api_v1.HTTPHeader{
+								{
+									Name:  "X-Custom-Header",
+									Value: "Awesome",
+								},
+							},
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
+				},
+			},
+		},
+		{
+			"Given all fields2",
+			true, `
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 15
+  periodSeconds: 20`,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						TCPSocket: &api_v1.TCPSocketAction{
+							Port: intstr.FromInt(8080),
+						},
+					},
+					InitialDelaySeconds: 5,
+					PeriodSeconds:       10,
+				},
+				LivenessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						TCPSocket: &api_v1.TCPSocketAction{
+							Port: intstr.FromInt(8080),
+						},
+					},
+					InitialDelaySeconds: 15,
+					PeriodSeconds:       20,
+				},
+			},
+		},
+		{
+			"Only required fields given",
+			true, `
+readinessProbe:
+  httpGet:
+    port: 8080`,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+
+							Port: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+		},
+		{
+			"Extra field given", // FIXME: this should fail ideally, see if an extra field is given
+			true, `
+readinessProbe:
+  httpGet:
+    port: 8080
+  foo: bar`,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+
+							Port: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+		},
+		{
+			"Wrong field type given",
+			false, `
+readinessProbe:
+  httpGet: foobar`,
+			nil,
+		},
+		{
+			"No fields given", // UnmarshalYAML won't be even called for empty strings -> default value
+			true,
+			``,
+			&Health{},
+		},
+		{
+			"Required field not given", // FIXME: this should fail ideally, see if the required fields not given
+			true, `
+readinessProbe:
+  initialDelaySeconds: 5`,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					InitialDelaySeconds: 5,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+
+			var health Health
+			err := yaml.Unmarshal([]byte(test.RawHealth), &health)
+			if err != nil {
+				if test.Succeed {
+					t.Errorf("failed to unmarshal 'Health': %q\nError: %v", test.RawHealth, err)
+				}
+				return
+			}
+
+			if !test.Succeed {
+				t.Fatalf("Expected %q to fail, but succeeded! Health object looks like: %s", test.RawHealth, spew.Sprint(health))
+			}
+
+			if !reflect.DeepEqual(health, *test.Health) {
+				t.Fatalf("Expected: %s\nGot: %s", spew.Sprint(test.Health), spew.Sprint(health))
+			}
+		})
+	}
+}
+
 func TestEmptyDirVolume_UnmarshalYAML(t *testing.T) {
 
 	tests := []struct {
@@ -744,6 +993,16 @@ services:
       mountPath: /foo/bar
       volumeSubPath: some/path
       readOnly: true
+    health:
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: 8080
+          httpHeaders:
+          - name: X-Custom-Header
+            value: Awesome
+        initialDelaySeconds: 3
+        periodSeconds: 3
   emptyDirVolumes:
   - name: empty
 volumes:
@@ -791,6 +1050,24 @@ volumes:
 										MountPath:     "/foo/bar",
 										VolumeSubPath: "some/path",
 										ReadOnly:      true,
+									},
+								},
+								Health: object.Health{
+									ReadinessProbe: &api_v1.Probe{
+										Handler: api_v1.Handler{
+											HTTPGet: &api_v1.HTTPGetAction{
+												Path: "/healthz",
+												Port: intstr.FromInt(8080),
+												HTTPHeaders: []api_v1.HTTPHeader{
+													{
+														Name:  "X-Custom-Header",
+														Value: "Awesome",
+													},
+												},
+											},
+										},
+										InitialDelaySeconds: 3,
+										PeriodSeconds:       3,
 									},
 								},
 							},

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -8,7 +8,10 @@ import (
 	"path"
 
 	"k8s.io/client-go/pkg/api/resource"
+	"k8s.io/client-go/pkg/util/intstr"
 	"k8s.io/client-go/pkg/util/validation"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 type PortMapping struct {
@@ -44,11 +47,17 @@ type Mount struct {
 
 type Labels map[string]string
 
+type Health struct {
+	ReadinessProbe *api_v1.Probe
+	LivenessProbe  *api_v1.Probe
+}
+
 type Container struct {
 	Image       string
 	Environment []EnvVariable
 	Ports       []Port
 	Mounts      []Mount
+	Health      Health
 }
 
 type EmptyDirVolume struct {
@@ -137,6 +146,141 @@ func (m *Mount) validate() error {
 	return nil
 }
 
+func validatePortNumOrName(p intstr.IntOrString) error {
+	var allErrs []string
+	if p.Type == intstr.Int {
+		allErrs = append(allErrs, validation.IsValidPortNum(p.IntValue())...)
+	} else if p.Type == intstr.String {
+		allErrs = append(allErrs, validation.IsValidPortName(p.String())...)
+	} else {
+		allErrs = append(allErrs, fmt.Sprintf("unknown type: %v", p))
+	}
+
+	if len(allErrs) > 0 {
+		return fmt.Errorf("errors with port: %s", strings.Join(allErrs, "\n"))
+	}
+	return nil
+}
+
+func validateExec(e *api_v1.ExecAction) error {
+	if len(e.Command) <= 0 {
+		return fmt.Errorf("required command(s), none given")
+	}
+	return nil
+}
+
+func validateHTTPGet(h *api_v1.HTTPGetAction) error {
+	// validate HTTPHeader
+	var allErrs []string
+	for _, header := range h.HTTPHeaders {
+		allErrs = append(allErrs, validation.IsHTTPHeaderName(header.Name)...)
+	}
+	if len(allErrs) > 0 {
+		return fmt.Errorf("errors with headers: %s", strings.Join(allErrs, "\n"))
+	}
+
+	// validate port
+	if err := validatePortNumOrName(h.Port); err != nil {
+		return err
+	}
+
+	// validate scheme
+	switch h.Scheme {
+	case api_v1.URISchemeHTTP, api_v1.URISchemeHTTPS, "":
+	default:
+		return fmt.Errorf("invalid scheme: %v", h.Scheme)
+	}
+
+	return nil
+}
+
+func validateTCPSocket(t *api_v1.TCPSocketAction) error {
+	if err := validatePortNumOrName(t.Port); err != nil {
+		return err
+	}
+	return nil
+}
+
+func positiveNumber(i int32) error {
+	if i < 0 {
+		return fmt.Errorf("invalid value: %d, must be greater than or equal to 0", i)
+	}
+	return nil
+}
+
+func validateProbes(p *api_v1.Probe) error {
+	// Probe is empty
+	if p == nil {
+		return nil
+	}
+
+	// not all of them can be nil
+	if p.Exec != nil && p.HTTPGet != nil && p.TCPSocket != nil {
+		return fmt.Errorf("Forbidden: may not specify more than 1 handler type, specified 'exec', 'httpGet', 'tcpSocket'")
+	} else if p.Exec != nil && p.HTTPGet != nil && p.TCPSocket == nil {
+		return fmt.Errorf("Forbidden: may not specify more than 1 handler type, specified 'exec', 'httpGet'")
+	} else if p.Exec != nil && p.TCPSocket != nil && p.HTTPGet == nil {
+		return fmt.Errorf("Forbidden: may not specify more than 1 handler type, specified 'exec', 'tcpSocket'")
+	} else if p.HTTPGet != nil && p.TCPSocket != nil && p.Exec == nil {
+		return fmt.Errorf("Forbidden: may not specify more than 1 handler type, specified 'httpGet', 'tcpSocket'")
+	}
+
+	if p.Exec != nil {
+		if err := validateExec(p.Exec); err != nil {
+			return fmt.Errorf("exec: %v", err)
+		}
+	}
+
+	if p.HTTPGet != nil {
+		if err := validateHTTPGet(p.HTTPGet); err != nil {
+			return fmt.Errorf("httpGet: %v", err)
+		}
+	}
+
+	if p.TCPSocket != nil {
+		// validate port
+		if err := validateTCPSocket(p.TCPSocket); err != nil {
+			return fmt.Errorf("tcpSocket: %v", err)
+		}
+	}
+
+	if err := positiveNumber(p.TimeoutSeconds); err != nil {
+		return fmt.Errorf("timeOutSeconds: %v", err)
+	}
+
+	if err := positiveNumber(p.FailureThreshold); err != nil {
+		return fmt.Errorf("failureThreshold: %v", err)
+	}
+
+	if err := positiveNumber(p.InitialDelaySeconds); err != nil {
+		return fmt.Errorf("initialDelaySeconds: %v", err)
+	}
+
+	if err := positiveNumber(p.PeriodSeconds); err != nil {
+		return fmt.Errorf("periodSeconds: %v", err)
+	}
+
+	if err := positiveNumber(p.SuccessThreshold); err != nil {
+		return fmt.Errorf("successThreshold: %v", err)
+	}
+
+	return nil
+}
+
+func (h *Health) validate() error {
+	err := validateProbes(h.LivenessProbe)
+	if err != nil {
+		return fmt.Errorf("failed to validate livenessProbe: %v\n", err)
+	}
+
+	err = validateProbes(h.ReadinessProbe)
+	if err != nil {
+		return fmt.Errorf("failed to validate readinessProbe: %v\n", err)
+	}
+
+	return nil
+}
+
 func (c *Container) validate() error {
 
 	// validate image name
@@ -163,6 +307,12 @@ func (c *Container) validate() error {
 		}
 		allMounts[mount.MountPath] = mount.VolumeRef
 	}
+
+	// validate healthchecks
+	if err := c.Health.validate(); err != nil {
+		return fmt.Errorf("failed to validate health: %v", err)
+	}
+
 	return nil
 }
 

--- a/pkg/object/object_test.go
+++ b/pkg/object/object_test.go
@@ -2,9 +2,13 @@ package object
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/redhat-developer/opencompose/pkg/goutil"
+	"k8s.io/client-go/pkg/util/intstr"
+
+	api_v1 "k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -86,6 +90,483 @@ func TestOpenCompose_VolumeExists(t *testing.T) {
 		if output != test.ExpectedSuccess {
 			t.Errorf("Expected output: %v but got: %v, for searching %q in volumes: %+v", test.ExpectedSuccess, output, test.Search, test.OpenCompose.Volumes)
 		}
+	}
+}
+
+func TestValidatePortNumOrName(t *testing.T) {
+	passTests := []intstr.IntOrString{
+		intstr.FromInt(1),
+		intstr.FromInt(1000),
+		intstr.FromInt(65535),
+
+		intstr.FromString("telnet"),
+		intstr.FromString("re-mail-ck"),
+		intstr.FromString("pop3"),
+		intstr.FromString("a"),
+		intstr.FromString("a-1"),
+		intstr.FromString("1-a"),
+		intstr.FromString("a-1-b-2-c"),
+		intstr.FromString("1-a-2-b-3"),
+	}
+
+	for _, test := range passTests {
+		err := validatePortNumOrName(test)
+		if err != nil {
+			t.Errorf("expected to pass, but failed for port - %v, got: %v", test.String(), err)
+			continue
+		}
+		t.Logf("expected to pass and passed for port - %v", test.String())
+	}
+
+	failTests := []intstr.IntOrString{
+		intstr.FromInt(-1),
+		intstr.FromInt(0),
+		intstr.FromInt(65536),
+		intstr.FromInt(100000),
+
+		intstr.FromString("longerthan15characters"),
+		intstr.FromString(""),
+		intstr.FromString(strings.Repeat("a", 16)),
+		intstr.FromString("12345"),
+		intstr.FromString("1-2-3-4"),
+		intstr.FromString("-begin"),
+		intstr.FromString("end-"),
+		intstr.FromString("two--hyphens"),
+		intstr.FromString("whois++"),
+	}
+
+	for _, test := range failTests {
+		err := validatePortNumOrName(test)
+		if err == nil {
+			t.Errorf("expected to fail, but passed for port - %v", test.String())
+			continue
+		}
+		t.Logf("expected to fail and failed for port - %v, got: %v", test.String(), err)
+	}
+}
+
+func TestValidateExec(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Exec            *api_v1.ExecAction
+	}{
+		{
+			"Command given",
+			true,
+			&api_v1.ExecAction{
+				Command: []string{"cat", "/tmp/healthz"},
+			},
+		},
+		{
+			"Command empty",
+			false,
+			&api_v1.ExecAction{
+				Command: []string{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := validateExec(test.Exec)
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateHTTPGet(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		HTTPGet         *api_v1.HTTPGetAction
+	}{
+		{
+			"Invalid scheme",
+			false,
+			&api_v1.HTTPGetAction{
+				Scheme: "http",
+				Port:   intstr.FromInt(80),
+			},
+		},
+		{
+			"Valid scheme",
+			true,
+			&api_v1.HTTPGetAction{
+				Scheme: "HTTP",
+				Port:   intstr.FromInt(80),
+			},
+		},
+		{
+			"Valid HTTPGet object",
+			true,
+			&api_v1.HTTPGetAction{
+				Path:   "/healthz",
+				Port:   intstr.FromInt(8080),
+				Scheme: "HTTPS",
+			},
+		},
+		{
+			"Invalid HTTP Header",
+			false,
+			&api_v1.HTTPGetAction{
+				HTTPHeaders: []api_v1.HTTPHeader{
+					{
+						Name:  "X-Forwarded-For:",
+						Value: "X-Forwarded-For:",
+					},
+				},
+				Port: intstr.FromInt(8080),
+			},
+		},
+		{
+			"Valid HTTP Header",
+			true,
+			&api_v1.HTTPGetAction{
+				HTTPHeaders: []api_v1.HTTPHeader{
+					{
+						Name:  "X-Forwarded-For",
+						Value: "X-Forwarded-For",
+					},
+				},
+				Port: intstr.FromInt(8080),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := validateHTTPGet(test.HTTPGet)
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateTCPSocket(t *testing.T) {
+	tests := []struct {
+		ExpectedSuccess bool
+		TCPSocket       *api_v1.TCPSocketAction
+	}{
+		{
+			false,
+			&api_v1.TCPSocketAction{Port: intstr.FromInt(0)},
+		},
+		{
+			true,
+			&api_v1.TCPSocketAction{Port: intstr.FromInt(1)},
+		},
+		{
+			true,
+			&api_v1.TCPSocketAction{Port: intstr.FromInt(65535)},
+		},
+		{
+			false,
+			&api_v1.TCPSocketAction{Port: intstr.FromInt(65536)},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			err := validateTCPSocket(test.TCPSocket)
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestPositiveNumber(t *testing.T) {
+	tests := []struct {
+		ExpectedSuccess bool
+		Number          int32
+	}{
+		{true, 0},
+		{true, 1},
+		{false, -1},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			err := positiveNumber(test.Number)
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateProbes(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Probe           *api_v1.Probe
+	}{
+		{
+			"No probe given",
+			true,
+			nil,
+		},
+		{
+			"Multiple handlers given, 'exec' and 'tcpSocket'",
+			false,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					Exec: &api_v1.ExecAction{
+						Command: []string{"cat", "/tmp/healthz"},
+					},
+					TCPSocket: &api_v1.TCPSocketAction{
+						Port: intstr.FromInt(80),
+					},
+				},
+			},
+		},
+		{
+			"Multiple handlers given, 'exec' and 'httpGet'",
+			false,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					Exec: &api_v1.ExecAction{
+						Command: []string{"cat", "/tmp/healthz"},
+					},
+					HTTPGet: &api_v1.HTTPGetAction{
+						Port: intstr.FromInt(80),
+					},
+				},
+			},
+		},
+		{
+			"Multiple handlers given, 'tcpSocket' and 'httpGet'",
+			false,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					HTTPGet: &api_v1.HTTPGetAction{
+						Port: intstr.FromInt(80),
+					},
+					TCPSocket: &api_v1.TCPSocketAction{
+						Port: intstr.FromInt(80),
+					},
+				},
+			},
+		},
+		{
+			"All handlers given",
+			false,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					HTTPGet: &api_v1.HTTPGetAction{
+						Port: intstr.FromInt(80),
+					},
+					TCPSocket: &api_v1.TCPSocketAction{
+						Port: intstr.FromInt(80),
+					},
+					Exec: &api_v1.ExecAction{
+						Command: []string{"cat", "/tmp/healthz"},
+					},
+				},
+			},
+		},
+		{
+			"Normal Probe given",
+			true,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					HTTPGet: &api_v1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+						Path: "/healthz",
+						HTTPHeaders: []api_v1.HTTPHeader{
+							{
+								Name:  "X-Custom-Header",
+								Value: "Awesome",
+							},
+						},
+					},
+				},
+				InitialDelaySeconds: 3,
+				PeriodSeconds:       3,
+			},
+		},
+		{
+			"Negative value for the positive fields",
+			false,
+			&api_v1.Probe{
+				Handler: api_v1.Handler{
+					HTTPGet: &api_v1.HTTPGetAction{
+						Port: intstr.FromInt(8080),
+					},
+				},
+				InitialDelaySeconds: -1,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := validateProbes(test.Probe)
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
+	}
+}
+
+func TestHealth_Validate(t *testing.T) {
+	tests := []struct {
+		Name            string
+		ExpectedSuccess bool
+		Health          *Health
+	}{
+		{
+			"Valid readinessProbe",
+			true,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+							Port: intstr.FromInt(8080),
+							Path: "/healthz",
+							HTTPHeaders: []api_v1.HTTPHeader{
+								{
+									Name:  "X-Custom-Header",
+									Value: "Awesome",
+								},
+							},
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
+				},
+			},
+		},
+		{
+			"Valid readinessProbe and valid livenessProbe",
+			true,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+							Port: intstr.FromInt(8080),
+							Path: "/healthz",
+							HTTPHeaders: []api_v1.HTTPHeader{
+								{
+									Name:  "X-Custom-Header",
+									Value: "Awesome",
+								},
+							},
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
+				},
+				LivenessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{
+							Command: []string{"cat", "/tmp/healthz"},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Valid readinessProbe and invalid livenssProbe",
+			false,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+							Port: intstr.FromInt(8080),
+							Path: "/healthz",
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
+				},
+				LivenessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{
+							Command: []string{},
+						},
+					},
+				},
+			},
+		},
+		{
+			"Invalid readinessProbe and valid livenssProbe",
+			false,
+			&Health{
+				ReadinessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						HTTPGet: &api_v1.HTTPGetAction{
+							Port: intstr.FromInt(80809),
+							Path: "/healthz",
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       3,
+				},
+				LivenessProbe: &api_v1.Probe{
+					Handler: api_v1.Handler{
+						Exec: &api_v1.ExecAction{
+							Command: []string{"cat", "/tmp/healthz"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			err := test.Health.validate()
+			if err != nil && test.ExpectedSuccess {
+				// failing condition
+				t.Fatalf("Expected success but failed with error: %v", err)
+			} else if err == nil && !test.ExpectedSuccess {
+				// failing condition
+				t.Fatal("Expected to fail but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				// passing condition
+				t.Logf("Failed with error: %v", err)
+			}
+		})
 	}
 }
 
@@ -523,6 +1004,79 @@ func TestOpenCompose_Validate(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"Valid Health values",
+			true,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+								Health: Health{
+									ReadinessProbe: &api_v1.Probe{
+										Handler: api_v1.Handler{
+											HTTPGet: &api_v1.HTTPGetAction{
+												Port: intstr.FromInt(8080),
+												Path: "/healthz",
+												HTTPHeaders: []api_v1.HTTPHeader{
+													{
+														Name:  "X-Custom-Header",
+														Value: "Awesome",
+													},
+												},
+											},
+										},
+										InitialDelaySeconds: 3,
+										PeriodSeconds:       3,
+									},
+									LivenessProbe: &api_v1.Probe{
+										Handler: api_v1.Handler{
+											Exec: &api_v1.ExecAction{
+												Command: []string{"cat", "/tmp/healthz"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			"Invalid Health value",
+			false,
+			&OpenCompose{
+				Version: Version,
+				Services: []Service{
+					{
+						Name: name,
+						Containers: []Container{
+							{
+								Image: image,
+								Health: Health{
+									ReadinessProbe: &api_v1.Probe{
+										Handler: api_v1.Handler{
+											HTTPGet: &api_v1.HTTPGetAction{
+												Port: intstr.FromInt(808000),
+												Path: "/healthz",
+											},
+										},
+										InitialDelaySeconds: 3,
+										PeriodSeconds:       3,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -533,6 +1087,8 @@ func TestOpenCompose_Validate(t *testing.T) {
 				t.Errorf("Expected success but failed as: %v", err)
 			} else if !test.ExpectedSuccess && err == nil {
 				t.Error("Expected failure but passed.")
+			} else if !test.ExpectedSuccess && err != nil {
+				t.Logf("Failed with error: %v", err)
 			}
 		})
 	}

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -241,6 +241,9 @@ func (t *Transformer) CreateDeployments(s *object.Service) ([]runtime.Object, er
 			}
 		}
 
+		kc.LivenessProbe = c.Health.LivenessProbe
+		kc.ReadinessProbe = c.Health.ReadinessProbe
+
 		d.Spec.Template.Spec.Containers = append(d.Spec.Template.Spec.Containers, kc)
 	}
 


### PR DESCRIPTION
Add support for providing things like livenessProbe and readinessProbe. Add a new field in container level called health which has readinessProbe and livenessProbe. These fields are identical to the way we define
livenessProbe or readinessProbe in kubernetes. So no new extra field has been added, everything that k8s supports works with the health option in OpenCompose.

fixes #24