### PR TITLE
Update reference documentation

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -1,8 +1,8 @@
-# OpenCompose file reference documentation
+## OpenCompose file reference
 
+_A brief example of the OpenCompose specification:_
 
-OpenCompose file example
-```yml
+```yaml
 version: "0.1-dev"
 
 services:
@@ -21,6 +21,9 @@ services:
     - "/tmp/foobar"
     ports:
     - port: 8080:80
+      type: internal
+      host: domain.tld
+      path: /admin
     mounts:
     - volumeRef: db
       mountPath: /app/store
@@ -37,104 +40,135 @@ volumes:
 ```
 
 
-OpenCompose file has three main sections *version*, *services* and *volumes*.
+The OpenCompose format has three main sections: *version*, *services* and *volumes*.
 
-## version
-| type  | required |
+## Section: Version
+
+```yaml
+version: "0.1-dev"
+```
+
+| Type  | Required |
 |-------|----------|
 |string |    yes   |
 
-Version of OpenCompose format.
+The current version of the OpenCompose format
 
-## services
-`services` is main section that lists all the services that this OpenCompose file describes.
-`services` has to be array of [ServiceSpec](#servicespec).
+## Section: Services
 
-### ServiceSpec
+```yaml
+services:
+- <Service>
+  ...
+
+- <Service>
+  ...
+```
+
+`services` is main section that lists all the services. 
+
+`services` is an array of [Service](#service).
+
+### Service
+
 Describes one service. Service can be composed of one or multiple containers which are scheduled
 together and can communicate using localhost. (Containers in the same service share network namespace.)
 
 Each service has name and list of the containers, while `replicas` can be optional.
 
-```yml
-# <ServiceSpec>
-  name: foo
-  replicas: 4
+_Example:_
+
+```yaml
+services:
+- name: foobar
+  replicas: 3
   labels:
     foo_label: bar_label
   containers:
-  - <ContainerSpec>
+  - <Container>
   emptyDirVolumes:
-  - <EmptyDirVolumeSpec>
+  - <EmptyDirVolume>
 ```
 
 #### name
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 Name of the service.
 
 #### replicas
-| type    | required |
+
+| Type    | Required |
 |---------|----------|
 | integer |    no    |
 
 Number of desired pods of this particluar service. This is an optional field. The valid value can only be a positive number.
 
 #### labels
-| type    | required |
+
+| Type    | Required |
 |---------|----------|
 | map with string keys and string values |    no    |
 
 Desired labels to be applied to the resulting Kubernetes objects from the service.
 
-### containers
-| type                                    | required |
-|-----------------------------------------|----------|
-|array of [ContainerSpec](#containerspec) |    yes   |
+#### containers
 
-Each item in [containers](#containers) ([ContainerSpec](#containerspec)) defines one container.
+| Type                                    | Required |
+|-----------------------------------------|----------|
+|array of [Container](#container) |    yes   |
+
+Each item in [containers](#containers) ([Container](#container)) defines one container.
 All the containers in container array for given service will be in same Pod.
 
-### emptyDirVolumes
-| type                                              | required |
+#### emptyDirVolumes
+
+| Type                                              | Required |
 |---------------------------------------------------|----------|
 |array of [EmptyDirVolumeSpec](#emptydirvolumespec) |    no    |
 
 Each item in [emptyDirVolumes](#emptydirvolumes) ([EmptyDirVolumeSpec](#emptydirvolumespec)) defines a EmptyDir volume.
 These volumes will be shared among the containers in the service.
 
-### ContainerSpec
-```yml
-# <ContainerSpec>
-  image: foo/bar:tag
-  env:
-  - name: VARIABLE
-    value: value
-  command:
-    - /foo/bar
-  args:
-    - "-foo"
-  ports:
-    - <PortSpec>
-  mounts:
-    - <MountSpec>
+### Container
+
+```yaml
+services:
+- name: foobar
+  ...
+  containers:
+  - image: foo/bar:tag
+    env:
+    - name: foo
+      value: bar
+    command: ["/bin/foobar"]
+    args:
+    - "-f"
+    - "/tmp/foobar"
+    ports:
+    - <Port>
+    mounts:
+    - <Mount>
+  ...
 ```
 
-ContainerSpec describes an image to use, its arguments, which ports should be exposed and how.
+Container describes an image to use, its arguments, which ports should be exposed and how.
 
 #### image
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 Name of the image that container will be started from.
 
 #### env
-| type            | required |
+
+| Type            | Required |
 |-----------------|----------|
-|array of [EnvSpec](#envspec) |    no    |
+|array of [EnvVariables](#envVariables) |    no    |
 
 List of environment variables to set in the container.
 Each string has to be formated as `variable_name=value`.
@@ -143,21 +177,21 @@ Each string has to be formated as `variable_name=value`.
 #### command
 **NOT YET IMPLEMENTED**
 
-| type           | required |
+| Type           | Required |
 |----------------|----------|
 |array of strings|    no    |
 
-Command run by the container.
-It overrides default Entrypoint from Docker container image.
+Command ran by the container. Overrides default Entrypoint from Docker container image.
 
 `command` field in in OpenCompose works in the same way as `command` filed in Kubernetes.
- You can find more about it in [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/container-command-args/)
+
+You can find more information in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/container-command-args/)
 
 
 #### args
 **NOT YET IMPLEMENTED**
 
-| type           | required |
+| Type           | Required |
 |----------------|----------|
 |array of strings|    no    |
 
@@ -169,57 +203,74 @@ This overrides default Command from Docker container image.
 
 #### ports
 
-| type                          | required |
+| Type                          | Required |
 |-------------------------------|----------|
-|array of [PortSpec](#portspec) |  no      |
+|array of [Port](#port) |  no      |
 
 This defines what ports will be exposed for communication.
 
 #### mounts
 
-| type                            | required |
+| Type                            | Required |
 |---------------------------------|----------|
-|array of [MountSpec](#mountspec) |  no      |
+|array of [Mount](#mount) |  no      |
 
 This defines what volumes will be mounted inside the container.
 
 
-### EnvSpec
-```yml
-# <EnvSpec>
-  name: DB_USER
-  value: bob
+### envVariables
+
+```yaml
+services:
+- name: foobar
+  ...
+  containers:
+    - ...
+      env:
+      - name: foo
+        value: bar
+    ...
+  ...
 ```
 
-Inside the containers, the environment variables will generally be visible as,
-DB_USER=bob
+Inside the containers, the environment variables will generally be visible as `foo=bar`.
 
 #### name
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 This is a string which defines the name of the environment variable being set.
 
 #### value
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 This is string which defines the value of the environment variable being set.
 
-### PortSpec
-```yml
-# <PortSpec>
-  port: 8080:80
-  type: internal
-  host: domain.tld
-  path: /admin
+### Port
 
+```yaml
+services:
+- name: foobar
+  ...
+  containers:
+    - ...
+      ports:
+        - port: 8080:80
+          type: internal
+          host: domain.tld
+          path: /admin
+    ...
+  ...
 ```
 
 #### port
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
@@ -231,24 +282,27 @@ This is a string in following format: `ContainerPort:ServicePort`
 
 
 #### type
-| type        | required | possible values         |
+
+| Type        | Required | possible values         |
 |-------------|----------|-------------------------|
 |enum(string) |    no    | `internal` or `external`|
 
-Default value for type is `internal`.
+Default value for Type is `internal`.
 
 - `internal` - port will be accessible only from inside the Kubernetes cluster
 - `external` - port will be accessible from inside and outside of the Kubernetes cluster
 
 #### host
-| type        | required | possible values                                           |
+
+| Type        | Required | possible values                                           |
 |-------------|----------|-----------------------------------------------------------|
 | string      |    no    | FQDN (fully qualified domain name) as defined by RFC 3986 |
 
 Specifying host will make your application accessible outside of the cluster on domain specified as a value of `host`. (Note: this requires you to manually setup DNS records to point to your cluster's Ingress router. For development you can use services like http://nip.io/ or [http://xip.io/].)
 
 #### path
-| type        | required | possible values                                               |
+
+| Type        | Required | possible values                                               |
 |-------------|----------|---------------------------------------------------------------|
 | string      |    no    | An extended POSIX regex as defined by IEEE Std 1003.1         |
 |             |          | (i.e this follows the egrep/unix syntax, not the perl syntax) |
@@ -257,6 +311,7 @@ Specifying host will make your application accessible outside of the cluster on 
 - You have to specify `host` if you want to specify `path`.
 
 ##### Path Based Ingresses
+
 Path based ingresses specify a path component that can be compared against a URL (which requires that the traffic for the ingress be HTTP based) such that multiple ingresses can be served using the same host name, each with a different path. Ingress controller should match ingresses based on the most specific path to the least; however, this depends on the ingress controller implementation. The following table shows example ingresses and their accessibility:
 
 | Ingress              | When Compared to     | Accessible |
@@ -268,86 +323,108 @@ Path based ingresses specify a path component that can be compared against a URL
 | www.example.com      | www.example.com/test | Yes (Matched by the host, not the ingress) |
 |                      | www.example.com      | Yes |
 
-### MountSpec
-```yml
-# <MountSpec>
-  volumeRef: db
-  mountPath: /app/store
-  volumeSubPath: foo/bar
-  readOnly: true
+### Mount
+
+```yaml
+...
+services:
+- name: foobar
+  ...
+  containers:
+    - ...
+      mounts:
+      - volumeRef: db
+        mountPath: /app/store
+        volumeSubPath: foo/bar
+        readOnly: true
+    ...
+...
 ```
 
 #### volumeRef
-| type | required | possible values                                                                 |
+
+| Type | Required | possible values                                                                 |
 |------|----------|---------------------------------------------------------------------------------|
 |string|    yes   | should conform to the definition of a subdomain in DNS (RFC 1123), [details](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md). |
 
 Should match the name of volume from root level [`volumes`](#volumes) directive or `service` level [`emptyDirVolumes`](#emptydirvolumes) directive.
 
 #### mountPath
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 Absolute path within the container at which the volume should be mounted. Must not contain ':'.
 
 #### volumeSubPath
-| type | required | Default value      |
+
+| Type | Required | Default value      |
 |------|----------|--------------------|
 |string|    no    | "" (volume's root) |
 
 Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
 
 #### readOnly
-| type | required | Default value |
+
+| Type | Required | Default value |
 |------|----------|---------------|
 |bool  |    no    | `false`       |
 
 Volume is mounted read-only if `true`, read-write otherwise.
 
 
-### EmptyDirVolumeSpec
-Describes one EmptyDir volume. This can be referenced from the [container mounts](#mountspec).
+### EmptyDirVolume
 
-```yml
-# <EmptyDirVolumeSpec>
-  name: tmp
+Describes one EmptyDir volume. This can be referenced from the [container mounts](#mount).
+
+```yaml
+services:
+- name: foobar
+  ...
+  emptyDirVolumes:
+  - name: temp
 ```
 
 #### name
-| type | required |
+
+| Type | Required |
 |------|----------|
 |string|    yes   |
 
 Name of the EmptyDir volume. 
 
 
-## volumes
+## Section: Volumes
+
 `volumes` is main section that lists all the volumes that this OpenCompose file describes.
 `volumes` has to be array of [VolumeSpec](#volumespec).
 
-### VolumeSpec
-Describes one volume. This can be referenced from the [container mounts](#mountspec).
+### Volume
+
+Describes one volume. This can be referenced from the [container mounts](#mount).
 
 Each volume has size defined, the accessmodes defined and storage class from where this should be read.
 
-```yml
-# <VolumeSpec>
-  name: db
+```yaml
+volumes:
+- name: db
   size: 5GiB
   accessMode: ReadWriteMany
   storageClass: fast
 ```
 
 #### name
-| type | required | possible values                                                                 |
+
+| Type | Required | possible values                                                                 |
 |------|----------|---------------------------------------------------------------------------------|
 |string|    yes   | should conform to the definition of a subdomain in DNS (RFC 1123), [details](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md). |
 
 Name of the volume.
 
 #### size
-| type | required | possible values                                                                   |
+
+| Type | Required | possible values                                                                   |
 |------|----------|-----------------------------------------------------------------------------------|
 |string|    yes   | must match the regular expression `'^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$` |
 
@@ -355,7 +432,7 @@ Size of the volume created.
 
 #### accessMode
 
-| type | required | possible values                                      |
+| Type | Required | possible values                                      |
 |------|----------|------------------------------------------------------|
 |string|    yes   | `ReadWriteOnce` or `ReadOnlyMany` or `ReadWriteMany` |
 
@@ -363,7 +440,7 @@ AccessMode contains the desired access mode the volume should have.
 
 #### storageClass
 
-| type | required |
+| Type | Required |
 |------|----------|
 |string|    no    | 
 


### PR DESCRIPTION
This updates the reference documenation in order to have a clearer image
in terms of what's going on with OpenCompose.

We also increase the spacing in-between the titles and rename a few
specification names (ex. PortSpec to Port) for simplicity.

We also switch to example-based learning. Going through each part of the
specification full-example.