### PR TITLE
add a mandatory "name" field to define containers

### DIFF
--- a/docs/file-reference.md
+++ b/docs/file-reference.md
@@ -11,7 +11,8 @@ services:
   labels:
     foo_label: bar_label
   containers:
-  - image: foo/bar:tag
+  - name: baz
+    image: foo/bar:tag
     env:
     - name: foo
       value: bar
@@ -139,7 +140,8 @@ services:
 - name: foobar
   ...
   containers:
-  - image: foo/bar:tag
+  - name: baz
+    image: foo/bar:tag
     env:
     - name: foo
       value: bar
@@ -155,6 +157,14 @@ services:
 ```
 
 Container describes an image to use, its arguments, which ports should be exposed and how.
+
+#### name
+
+| Type | Required |
+|------|----------|
+|string|    yes   |
+
+Name of the container.
 
 #### image
 

--- a/examples/hello-nginx-external.yaml
+++ b/examples/hello-nginx-external.yaml
@@ -3,6 +3,7 @@ services:
 - name: helloworld
   containers:
   - image: nginx
+    name: nginx
     ports:
     - port: 80:8080
       type: external

--- a/examples/hello-nginx-with-route.yaml
+++ b/examples/hello-nginx-with-route.yaml
@@ -3,6 +3,7 @@ services:
 - name: helloworld
   containers:
   - image: nginx
+    name: nginx
     ports:
     - port: 80:8080
       host: hw-nginx.127.0.0.1.nip.io

--- a/examples/hello-nginx.yaml
+++ b/examples/hello-nginx.yaml
@@ -3,5 +3,6 @@ services:
 - name: helloworld
   containers:
   - image: nginx
+    name: nginx
     ports:
     - port: 80

--- a/examples/wordpress/no-storage.yaml
+++ b/examples/wordpress/no-storage.yaml
@@ -4,6 +4,7 @@ services:
 - name: database
   containers:
   - image: mariadb:10
+    name: mariadb
     env:
     - name: MYSQL_ROOT_PASSWORD
       value: rootpasswd
@@ -19,6 +20,7 @@ services:
 - name: web
   containers:
   - image: wordpress:4
+    name: wordpress
     env:
     - name: WORDPRESS_DB_HOST
       value: database:3306

--- a/examples/wordpress/storage.yaml
+++ b/examples/wordpress/storage.yaml
@@ -4,6 +4,7 @@ services:
 - name: database
   containers:
   - image: mariadb:10
+    name: mariadb
     env:
     - name: MYSQL_ROOT_PASSWORD
       value: rootpasswd
@@ -22,6 +23,7 @@ services:
 - name: web
   containers:
   - image: wordpress:4
+    name: wordpress
     env:
     - name: WORDPRESS_DB_HOST
       value: database:3306

--- a/examples/wordpress/storage_labels.yml
+++ b/examples/wordpress/storage_labels.yml
@@ -6,6 +6,7 @@ services:
     app: db
   containers:
   - image: mariadb:10
+    name: mariadb
     env:
       - MYSQL_ROOT_PASSWORD=rootpasswd
       - MYSQL_DATABASE=wordpress
@@ -22,6 +23,7 @@ services:
     app: web
   containers:
   - image: wordpress:4
+    name: wordpress
     env:
     - WORDPRESS_DB_HOST=database:3306
     - WORDPRESS_DB_PASSWORD=wordpress

--- a/pkg/encoding/v1/encoding.go
+++ b/pkg/encoding/v1/encoding.go
@@ -220,6 +220,7 @@ func (m *Mount) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type Container struct {
+	Name   ResourceName  `yaml:"name"`
 	Image  ImageRef      `yaml:"image"`
 	Env    []EnvVariable `yaml:"env,omitempty"`
 	Ports  []Port        `yaml:"ports,omitempty"`
@@ -409,6 +410,7 @@ func (d *Decoder) Decode(data []byte) (*object.OpenCompose, error) {
 		// convert containers
 		for _, c := range s.Containers {
 			oc := object.Container{
+				Name:  string(c.Name),
 				Image: string(c.Image),
 			}
 

--- a/pkg/encoding/v1/encoding_test.go
+++ b/pkg/encoding/v1/encoding_test.go
@@ -502,6 +502,7 @@ key4: value4
 }
 
 func TestService_UnmarshalYAML(t *testing.T) {
+	containerName := ResourceName("test")
 	tests := []struct {
 		Name       string
 		Succeed    bool
@@ -515,12 +516,14 @@ name: frontend
 replicas: 3
 containers:
 - image: tomaskral/kompose-demo-frontend:test
+  name: test
 `,
 			&Service{
 				Name:     "frontend",
 				Replicas: goutil.Int32Addr(3),
 				Containers: []Container{
 					{
+						Name:  containerName,
 						Image: "tomaskral/kompose-demo-frontend:test",
 					},
 				},
@@ -534,6 +537,7 @@ name: frontend
 replicas: notint
 containers:
 - image: tomaskral/kompose-demo-frontend:test
+  name: test
 `,
 			nil,
 		},
@@ -544,11 +548,13 @@ containers:
 name: frontend
 containers:
 - image: tomaskral/kompose-demo-frontend:test
+  name: test
 `,
 			&Service{
 				Name: "frontend",
 				Containers: []Container{
 					{
+						Name:  containerName,
 						Image: "tomaskral/kompose-demo-frontend:test",
 					},
 				},
@@ -561,6 +567,7 @@ containers:
 name: frontend
 containers:
 - image: tomaskral/kompose-demo-frontend:test
+  name: test
   mounts:
   - volumeRef: test-volume
     mountPath: /foo/bar
@@ -571,6 +578,7 @@ containers:
 				Name: "frontend",
 				Containers: []Container{
 					{
+						Name:  containerName,
 						Image: "tomaskral/kompose-demo-frontend:test",
 						Mounts: []Mount{
 							{
@@ -591,6 +599,7 @@ containers:
 name: frontend
 containers:
 - image: tomaskral/kompose-demo-frontend:test
+  name: test
 emptyDirVolumes:
 - name: empty
 `,
@@ -598,6 +607,7 @@ emptyDirVolumes:
 				Name: "frontend",
 				Containers: []Container{
 					{
+						Name:  containerName,
 						Image: "tomaskral/kompose-demo-frontend:test",
 					},
 				},
@@ -719,6 +729,7 @@ func TestDecoder_Decode(t *testing.T) {
 	// TODO: make better tests w.r.t excess keys in all possible places
 	// TODO: add checking for proper error because tests can fail for other than expected reasons
 
+	containerName := "test"
 	tests := []struct {
 		Succeed     bool
 		File        string
@@ -731,6 +742,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -759,6 +771,7 @@ volumes:
 						Name: "frontend",
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/kompose-demo-frontend:test",
 								Environment: []object.EnvVariable{
 									{
@@ -819,6 +832,7 @@ services:
 - name: helloworld
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
     ports:
     - port: 8080
       type: external
@@ -830,6 +844,7 @@ services:
 						Name: "helloworld",
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/nonroot-nginx",
 								Ports: []object.Port{
 									{
@@ -853,6 +868,7 @@ services:
 - name: helloworld
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
     ports:
     - port: 8080
       type: internal
@@ -864,6 +880,7 @@ services:
 						Name: "helloworld",
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/nonroot-nginx",
 								Ports: []object.Port{
 									{
@@ -887,6 +904,7 @@ services:
 - name: helloworld
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
     ports:
     - port: 8080
       host: hw-nginx.127.0.0.1.nip.io
@@ -899,6 +917,7 @@ services:
 						Name: "helloworld",
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/nonroot-nginx",
 								Ports: []object.Port{
 									{
@@ -924,6 +943,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
 	- name: KEY
 	  value: value
@@ -942,6 +962,7 @@ version: 0.1-dev
 services:
 - name: frontend
   containers:
+    name: test
   - image: tomaskral/kompose-demo-frontend:test
 	env:
 	- name: KEY
@@ -966,6 +987,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -980,6 +1002,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -994,6 +1017,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -1009,6 +1033,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -1033,6 +1058,7 @@ services:
 - name: frontend
   containers:
   - image: tomaskral/kompose-demo-frontend:test
+    name: test
     env:
     - name: KEY
       value: value
@@ -1050,6 +1076,7 @@ volumes: []
 						Name: "frontend",
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/kompose-demo-frontend:test",
 								Environment: []object.EnvVariable{
 									{
@@ -1102,6 +1129,7 @@ services:
   replicas: 2
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
 `,
 			&object.OpenCompose{
 				Version: Version,
@@ -1111,6 +1139,7 @@ services:
 						Replicas: goutil.Int32Addr(2),
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/nonroot-nginx",
 							},
 						},
@@ -1126,6 +1155,7 @@ services:
   replicas: 2
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
     mounts:
     - volumeRef: test-volume
       readOnly: true
@@ -1139,6 +1169,7 @@ services:
 - name: helloworld
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
 volumes:
 - name: db
   size: 5Gi
@@ -1155,6 +1186,7 @@ services:
   replicas: 2
   containers:
   - image: tomaskral/nonroot-nginx
+    name: test
   labels:
       key1: value1
       key2: value2
@@ -1169,6 +1201,7 @@ services:
 						Replicas: goutil.Int32Addr(2),
 						Containers: []object.Container{
 							{
+								Name:  containerName,
 								Image: "tomaskral/nonroot-nginx",
 							},
 						},

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -45,6 +45,7 @@ type Mount struct {
 type Labels map[string]string
 
 type Container struct {
+	Name        string
 	Image       string
 	Environment []EnvVariable
 	Ports       []Port

--- a/pkg/transform/kubernetes/kubernetes.go
+++ b/pkg/transform/kubernetes/kubernetes.go
@@ -194,9 +194,9 @@ func (t *Transformer) CreateDeployments(s *object.Service) ([]runtime.Object, er
 
 	d.Spec.Replicas = s.Replicas
 
-	for i, c := range s.Containers {
+	for _, c := range s.Containers {
 		kc := api_v1.Container{
-			Name:  fmt.Sprintf("%s-%d", s.Name, i),
+			Name:  c.Name,
 			Image: c.Image,
 		}
 
@@ -209,7 +209,7 @@ func (t *Transformer) CreateDeployments(s *object.Service) ([]runtime.Object, er
 
 		for _, p := range c.Ports {
 			kc.Ports = append(kc.Ports, api_v1.ContainerPort{
-				Name:          fmt.Sprintf("port-%d", p.Port.ContainerPort),
+				Name:          c.Name,
 				ContainerPort: int32(p.Port.ContainerPort),
 			})
 		}

--- a/pkg/transform/kubernetes/kubernetes_test.go
+++ b/pkg/transform/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -579,7 +578,7 @@ func TestTransformer_CreateIngresses(t *testing.T) {
 
 func TestTransformer_CreateDeployments(t *testing.T) {
 	name := "test"
-	podname := fmt.Sprintf("%s-%d", name, 0)
+	containerName := "test"
 	image := "docker.io/test"
 	sMeta := api_v1.ObjectMeta{
 		Name: name,
@@ -604,6 +603,7 @@ func TestTransformer_CreateDeployments(t *testing.T) {
 				Name: name,
 				Containers: []object.Container{
 					{
+						Name:  containerName,
 						Image: image,
 					},
 				},
@@ -622,7 +622,7 @@ func TestTransformer_CreateDeployments(t *testing.T) {
 							Spec: api_v1.PodSpec{
 								Containers: []api_v1.Container{
 									{
-										Name:  podname,
+										Name:  containerName,
 										Image: image,
 									},
 								},
@@ -640,6 +640,7 @@ func TestTransformer_CreateDeployments(t *testing.T) {
 				Replicas: goutil.Int32Addr(1),
 				Containers: []object.Container{
 					{
+						Name:  containerName,
 						Image: image,
 					},
 				},
@@ -659,7 +660,7 @@ func TestTransformer_CreateDeployments(t *testing.T) {
 							Spec: api_v1.PodSpec{
 								Containers: []api_v1.Container{
 									{
-										Name:  podname,
+										Name:  containerName,
 										Image: image,
 									},
 								},


### PR DESCRIPTION
This commit adds a mandatory field "name" to the containers
definition in the OpenCompose spec. Using this field, we can
mention the name of the container.

Prior to this commit, a minimal OpenCompose file would look like -

```
version: "0.1-dev"

services:
- name: foobar
  containers:
  - image: foo/bar:tag

```

Now, a "name" field for every container is mandatory to be
specified-

```
version: "0.1-dev"

services:
- name: foobar
  containers:
  - name: baz
    image: foo/bar:tag

```

This commit also fixes docs, updates tests for the changes,
updates examples.