### PR TITLE
Add ``` to user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -45,7 +45,7 @@ source <(kompose completion bash)
 
 ```sh
 source <(kompose completion zsh)
-
+```
 
 ## `opencompose validate`
 


### PR DESCRIPTION
Forgot to add the ending ``` to the documentation